### PR TITLE
Make sure callback happens if a model is not attached to the data source

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -371,22 +371,34 @@ SqlConnector.prototype.automigrate = function (models, cb) {
   }
 
   models = models || Object.keys(self._models);
-  async.each(models, function (model, callback) {
-    if (model in self._models) {
-      self.dropTable(model, function (err) {
+  if (models.length === 0) {
+    return process.nextTick(cb);
+  }
+
+  var invalidModels = models.filter(function(m) {
+      return !(m in self._models);
+    });
+  if (invalidModels.length) {
+    return process.nextTick(function() {
+      cb(new Error('Cannot migrate models not attached to this datasource: ' +
+        invalidModels.join(' ')));
+    });
+  }
+
+  async.each(models, function(model, done) {
+    self.dropTable(model, function(err) {
+      if (err) {
+        // TODO(bajtos) should we abort here and call cb(err)?
+        // The original code in juggler ignored the error completely
+        console.error(err);
+      }
+      self.createTable(model, function(err, result) {
         if (err) {
-          // TODO(bajtos) should we abort here and call cb(err)?
-          // The original code in juggler ignored the error completely
           console.error(err);
         }
-        self.createTable(model, function (err, result) {
-          if (err) {
-            console.error(err);
-          }
-          callback(err, result);
-        });
+        done(err, result);
       });
-    }
+    });
   }, cb);
 };
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "async": "^0.9.0"
   },
   "devDependencies": {
+    "chai": "~1.9.2",
+    "loopback-datasource-juggler": "^2.0.0",
     "mocha": "^1.19.0"
   }
 }

--- a/test/automigrate.test.js
+++ b/test/automigrate.test.js
@@ -1,0 +1,48 @@
+var expect = require('chai').expect;
+var testConnector = require('./connectors/test-sql-connector');
+
+var juggler = require('loopback-datasource-juggler');
+var ds = new juggler.DataSource({
+  connector: testConnector,
+  debug: true
+});
+
+describe('sql connector', function() {
+  beforeEach(function() {
+    ds.connector._tables = {};
+    ds.connector._models = {};
+    ds.createModel('m1', {});
+  });
+
+  it('automigrate all models', function(done) {
+    ds.automigrate(function(err) {
+      expect(ds.connector._tables).have.property('m1');
+      done(err);
+    });
+  });
+
+  it('automigrate one model', function(done) {
+    ds.automigrate('m1', function(err) {
+      expect(ds.connector._tables).have.property('m1');
+      done(err);
+    });
+  });
+
+  it('automigrate one or more models in an array', function(done) {
+    ds.automigrate(['m1'], function(err) {
+      expect(ds.connector._tables).have.property('m1');
+      done(err);
+    });
+  });
+
+  it('automigrate reports errors for models not attached', function(done) {
+    ds.automigrate(['m1', 'm2'], function(err) {
+      expect(err).to.be.an.instanceOf(Error);
+      expect(ds.connector._tables).to.not.have.property('m1');
+      expect(ds.connector._tables).to.not.have.property('m2');
+      done();
+    });
+  });
+
+});
+

--- a/test/connectors/test-sql-connector.js
+++ b/test/connectors/test-sql-connector.js
@@ -1,0 +1,49 @@
+/*
+ * A mockup connector that extends SQL connector
+ */
+var util = require('util');
+var SqlConnector = require('../../lib/sql');
+
+exports.initialize = function initializeDataSource(dataSource, callback) {
+  process.nextTick(function() {
+    if(callback) {
+      var connector = new TestConnector();
+      connector.dataSource = dataSource;
+      dataSource.connector = connector;
+      callback(null, connector);
+    }
+  });
+};
+
+function TestConnector() {
+  SqlConnector.apply(this, [].slice.call(arguments));
+  this._tables = {};
+}
+
+util.inherits(TestConnector, SqlConnector);
+
+TestConnector.prototype.dropTable = function(model, cb) {
+  var err;
+  var exists = model in this._tables;
+  if (!exists) {
+    err = new Error('Model doesn\'t exist: ' + model);
+  } else {
+    delete this._tables[model];
+  }
+  process.nextTick(function() {
+    cb(err);
+  });
+};
+
+TestConnector.prototype.createTable = function(model, cb) {
+  var err;
+  var exists = model in this._tables;
+  if (exists) {
+    err = new Error('Model already exists: ' + model);
+  } else {
+    this._tables[model] = model;
+  }
+  process.nextTick(function() {
+    cb(err);
+  });
+};


### PR DESCRIPTION
/to @bajtos or @ritch 

The PR fixes a hang issue during `automigrate` if one of the models is not attached to the data source.

I'll add a test in connectors.
