### PR TITLE
fix: support additional values for Connector.isNullable

### DIFF
--- a/lib/connector.js
+++ b/lib/connector.js
@@ -335,16 +335,17 @@ Connector.prototype.setIdValue = function(model, data, value) {
  * @returns {boolean} true if nullable
  */
 Connector.prototype.isNullable = function(prop) {
-  if (prop.required || prop.id) {
+  if (prop.required || prop.id)
     return false;
+
+  const nullableFlagsValue = [prop.nullable, prop['null'], prop.allowNull];
+  const notNullableValues = [0, 'N', 'NO', false];
+
+  for (const flagValue of nullableFlagsValue) {
+    if (notNullableValues.includes(flagValue))
+      return false;
   }
-  if (prop.nullable || prop['null'] || prop.allowNull) {
-    return true;
-  }
-  if (prop.nullable === false || prop['null'] === false ||
-    prop.allowNull === false) {
-    return false;
-  }
+
   return true;
 };
 

--- a/test/connector.test.js
+++ b/test/connector.test.js
@@ -97,16 +97,90 @@ describe('Connector', () => {
     });
 
     it('should return undefined for non-existing nested property', () => {
-      const definition = connector.getPropertyDefinition('MyModel',
-        'someProp.innerArray.foo');
+      const definition = connector.getPropertyDefinition(
+        'MyModel',
+        'someProp.innerArray.foo',
+      );
       // eslint-disable-next-line no-unused-expressions
       expect(definition).to.be.undefined;
     });
 
     it('should preserve backward-compatibility for non-existing property', () => {
-      const definition = connector.getPropertyDefinition('MyModel', 'idontexist');
+      const definition = connector.getPropertyDefinition(
+        'MyModel',
+        'idontexist',
+      );
       // eslint-disable-next-line no-unused-expressions
       expect(definition).to.be.undefined;
     });
+  });
+
+  describe('isNullable()', () => {
+    const nullableOverrideFlags = ['required', 'id'];
+
+    const nullableFlags = ['nullable', 'null', 'allowNull'];
+
+    const nullableValues = [1, 'Y', 'YES', true];
+
+    const notNullableValues = [0, 'N', 'NO', false];
+
+    for (const nullableOverrideFlag of nullableOverrideFlags) {
+      const propDefNullableOverridePlainSlice = {
+        [nullableOverrideFlag]: true,
+      };
+      it(`returns \`false\` for \`${JSON.stringify(
+        propDefNullableOverridePlainSlice,
+      )}`, () => {
+        const result = Connector.prototype.isNullable(
+          propDefNullableOverridePlainSlice,
+        );
+        // eslint-disable-next-line no-unused-expressions
+        expect(result).to.be.false;
+      });
+
+      for (const nullableFlag of nullableFlags) {
+        for (const nullableValue of nullableValues) {
+          const propDefNullableOverrideSlice = {
+            ...propDefNullableOverridePlainSlice,
+            [nullableFlag]: nullableValue,
+          };
+          it(`returns \`false\` for \`${JSON.stringify(
+            propDefNullableOverrideSlice,
+          )}`, () => {
+            const result = Connector.prototype.isNullable(
+              propDefNullableOverrideSlice,
+            );
+            // eslint-disable-next-line no-unused-expressions
+            expect(result).to.be.false;
+          });
+        }
+      }
+    }
+
+    for (const nullableFlag of nullableFlags) {
+      for (const nullableValue of nullableValues) {
+        const propDefNullableSlice = {[nullableFlag]: nullableValue};
+        it(`returns \`true\` for \`${JSON.stringify(
+          propDefNullableSlice,
+        )}\``, () => {
+          const result = Connector.prototype.isNullable(propDefNullableSlice);
+          // eslint-disable-next-line no-unused-expressions
+          expect(result).to.be.true;
+        });
+      }
+
+      for (const notNullableValue of notNullableValues) {
+        const propDefNotNullableSlice = {[nullableFlag]: notNullableValue};
+        it(`returns \`false\` for \`${JSON.stringify(
+          propDefNotNullableSlice,
+        )}\``, () => {
+          const result = Connector.prototype.isNullable(
+            propDefNotNullableSlice,
+          );
+          // eslint-disable-next-line no-unused-expressions
+          expect(result).to.be.false;
+        });
+      }
+    }
   });
 });


### PR DESCRIPTION
There's inconsistent implementation on checking if a property has the "nullable" characteristic. As such, connectors (including our own) don't always (or never) utilise `Connector.isNullable()`.

This PR attempts to cover all possible flag values (for "not nullable") while keeping the liberal "default-to-nullable" logic. Hence in theory, it should be backwards compatible.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
