### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 LoopBack Connector is a set of building blocks simplifying implementation
 of datasource-specific connectors like Oracle, MongoDB, REST.
 
-**For full documentation, see the official StrongLoop documentation**:
- * [Data sources and connectors](http://docs.strongloop.com/display/public/LB/Database+connectors)
+**For full documentation, see the official LoopBack documentation**:
+ * [Data sources and connectors](https://loopback.io/doc/en/lb4/Connectors-reference.html)
 
 ## Installation
 
@@ -15,5 +15,5 @@ of datasource-specific connectors like Oracle, MongoDB, REST.
 
 ## Usage
 
-See [loopback-connector-mysql](https://github.com/strongloop/loopback-connector-mysql) 
+See [loopback-connector-mysql](https://github.com/loopbackio/loopback-connector-mysql) 
 for an example of connector using this module.


### PR DESCRIPTION
Signed-off-by: Shubham Prajapat <shubham.prajapat@sourcefuse.com>

Replaced broken connector reference link, and updated StrongLoop pointed GitHub link of mysql connector repo.


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
