### PR TITLE
fix: return inserted ids with models in createAll

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -707,8 +707,16 @@ SQLConnector.prototype.createAll = function(model, data, options, callback) {
     if (err) {
       callback(err);
     } else {
-      const insertedId = self.getInsertedId(model, info);
-      callback(err, insertedId);
+      const insertedIds = self.getInsertedIds(model, info);
+      // We need to parse the ids created and map them back into the model
+      const returnData = [];
+      const idPropName = self.propertyName(model, self.idColumn(model));
+      for (let i = 0; i < insertedIds.length; i++) {
+        const saved = Object.assign({}, data[i]);
+        saved[idPropName] = insertedIds[i];
+        returnData.push(saved);
+      }
+      callback(err, returnData);
     }
   });
 };
@@ -1796,6 +1804,16 @@ SQLConnector.prototype.getCountForAffectedRows = function(model, info) {
  */
 SQLConnector.prototype.getInsertedId = function(model, info) {
   throw new Error(g.f('{{getInsertedId()}} must be implemented by the connector'));
+};
+
+/**
+ * Parse the result for SQL INSERT (bulk) for newly inserted ids
+ * @param {String} model Model name
+ * @param {Object} info The status object from driver
+ * @returns {*} The inserted id values as an array
+ */
+SQLConnector.prototype.getInsertedIds = function(model, info) {
+  throw new Error(g.f('{{getInsertedIds()}} must be implemented by the connector'));
 };
 
 /**


### PR DESCRIPTION
Signed-off-by: Samarpan Bhattacharya <this.is.samy@gmail.com>

Fixes an issue with newly introduced createAll() method where it was not returning all ids of inserted records. The format of the data returned was also wrong. Introduced a new base function getInsertedIds() which needs to be implemented by connectors if they use multi insert support. It is similar to getInsertedId().

See also https://github.com/loopbackio/loopback-connector/issues/227 and https://github.com/loopbackio/loopback-next/issues/3357

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
