### PR TITLE
fix: remove readOnly keys from query

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1314,7 +1314,7 @@ SQLConnector.prototype._buildFieldsForKeys = function(model, data, keys, exclude
       continue;
     }
 
-    if (excludeIds && p.id) {
+    if ((excludeIds && p.id) || p.readOnly) {
       continue;
     }
     const k = this.columnEscaped(model, key);

--- a/test/name-mapping.test.js
+++ b/test/name-mapping.test.js
@@ -57,6 +57,14 @@ describe('Name mapping', function() {
           type: String,
           name: 'primary_address',
         },
+        token: {
+          type: String,
+          name: 'token',
+          readOnly: true,
+          testdb: {
+            column: 'TOKEN',
+          },
+        },
         address: String,
       },
       {testdb: {table: 'CUSTOMER'}},

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -55,6 +55,13 @@ describe('sql connector', function() {
         }, primaryAddress: {
           type: String,
           name: 'primary_address',
+        }, token: {
+          type: String,
+          name: 'token',
+          readOnly: true,
+          testdb: {
+            column: 'TOKEN',
+          },
         },
         address: String,
       },
@@ -278,6 +285,27 @@ describe('sql connector', function() {
     );
   });
 
+  it('builds fields for UPDATE without readOnlys', function() {
+    const fields = connector.buildFieldsForReplace('customer', {
+      middleName: '',
+      lastName: 'Libert',
+      vip: true,
+      token: null,
+      address: '1031 NW 7th Ave, Fort Lauderdale, Florida, United States',
+      primaryAddress: '1031 NW 7th Ave, Fort Lauderdale, Florida, United States',
+    });
+    expect(fields.toJSON()).to.eql({
+      sql: 'SET `middle_name`=?,`LASTNAME`=?,`VIP`=?,`primary_address`=?,`ADDRESS`=?',
+      params: [
+        '',
+        'Libert',
+        true,
+        '1031 NW 7th Ave, Fort Lauderdale, Florida, United States',
+        '1031 NW 7th Ave, Fort Lauderdale, Florida, United States',
+      ],
+    });
+  });
+
   it('builds fields for UPDATE without ids', function() {
     const fields = connector.buildFieldsForUpdate('customer',
       {name: 'John', vip: true});
@@ -299,7 +327,7 @@ describe('sql connector', function() {
   it('builds column names for SELECT', function() {
     const cols = connector.buildColumnNames('customer');
     expect(cols).to.eql('`NAME`,`middle_name`,`LASTNAME`,`VIP`,' +
-      '`primary_address`,`ADDRESS`');
+      '`primary_address`,`TOKEN`,`ADDRESS`');
   });
 
   it('builds column names with true fields filter for SELECT', function() {
@@ -313,6 +341,7 @@ describe('sql connector', function() {
         name: false,
         primaryAddress: false,
         lastName: false,
+        token: false,
         middleName: false,
       },
     });
@@ -349,7 +378,7 @@ describe('sql connector', function() {
     expect(sql.toJSON()).to.eql({
       sql:
         'SELECT `NAME`,`middle_name`,`LASTNAME`,`VIP`,`primary_address`,' +
-        '`ADDRESS` FROM `CUSTOMER` WHERE ((`NAME`=$1) OR (`ADDRESS`=$2)) ' +
+        '`TOKEN`,`ADDRESS` FROM `CUSTOMER` WHERE ((`NAME`=$1) OR (`ADDRESS`=$2)) ' +
         'AND `VIP`=$3 ORDER BY `NAME` LIMIT 5',
       params: ['Top Cat', 'Trash can', true],
     });
@@ -359,8 +388,8 @@ describe('sql connector', function() {
     const sql = connector.buildSelect('customer',
       {order: 'name', limit: 5, where: {name: 'John'}});
     expect(sql.toJSON()).to.eql({
-      sql: 'SELECT `NAME`,`middle_name`,`LASTNAME`,`VIP`,`primary_address`,`ADDRESS`' +
-      ' FROM `CUSTOMER`' +
+      sql: 'SELECT `NAME`,`middle_name`,`LASTNAME`,`VIP`,`primary_address`,`TOKEN`,' +
+      '`ADDRESS` FROM `CUSTOMER`' +
       ' WHERE `NAME`=$1 ORDER BY `NAME` LIMIT 5',
       params: ['John'],
     });


### PR DESCRIPTION
This PR removes the readOnly fields from the SQL query.

See also #[9339](https://github.com/loopbackio/loopback-next/pull/9339)

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
