### PR TITLE
chore: drop support for Node.js 16 and lower

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -20,12 +20,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [16, 18, 20]
+        node-version: [18, 20]
         include:
           - os: macos-latest
-            node_version: 16
+            node_version: 18
           - os: windows-latest
-            node_version: 16
+            node_version: 18
       fail-fast: false
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -60,10 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: 16
+          node-version: 18
       - name: Bootstrap project
         run: npm ci --ignore-scripts
       - name: Verify code linting
@@ -76,10 +76,10 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: 16
+          node-version: 18
       - name: Bootstrap project
         run: npm ci --ignore-scripts
       - name: Verify commit linting

--- a/.npmignore
+++ b/.npmignore
@@ -17,3 +17,4 @@ loopback-connector-*.tgz
 coverage
 .vscodetest
 .travis.yml
+test

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.3",
   "description": "Building blocks for LoopBack connectors",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "author": "IBM Corp.",
   "keywords": [


### PR DESCRIPTION
BREAKING-CHANGE: drop support for Node.js 16 and lower

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
