### PR TITLE
feat: pass options to buildQueryColumns

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1913,7 +1913,7 @@ SQLConnector.prototype.discoverModelDefinitions = function(options, cb) {
  */
 // Due to the different implementation structure of information_schema across
 // connectors, each connector will have to generate its own query
-SQLConnector.prototype.buildQueryColumns = function(schema, table) {
+SQLConnector.prototype.buildQueryColumns = function(schema, table, options) {
   throw new Error(g.f('{{buildQueryColumns}} must be implemented by the connector'));
 };
 
@@ -1957,7 +1957,7 @@ SQLConnector.prototype.discoverModelProperties = function(table, options, cb) {
   self.setDefaultOptions(options);
   cb = args.cb;
 
-  const sql = self.buildQueryColumns(schema, table);
+  const sql = self.buildQueryColumns(schema, table, options);
   const callback = function(err, results) {
     if (err) {
       cb(err, results);


### PR DESCRIPTION
Passing options to connector's buildQueryColumns function.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
