### PR TITLE
fix: handle undefined properties in insert all

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1269,10 +1269,18 @@ SQLConnector.prototype.buildFields = function(model, data, excludeIds) {
  */
 SQLConnector.prototype.buildFieldsFromArray = function(model, data, excludeIds) {
   const fields = [];
+  const keysObj = {};
   if (Array.isArray(data) && data.length > 0) {
-    const keys = Object.keys(data[0]);
     for (let i = 0; i < data.length; i++) {
-      fields.push(this._buildFieldsForKeys(model, data[i], keys, excludeIds));
+      const dataItem = data[i];
+      if (!dataItem) continue;
+      const keys = Object.keys(dataItem);
+      for (const key of keys || [])
+        keysObj[key] = true;
+    }
+    const allKeys = Object.keys(keysObj);
+    for (let i = 0; i < data.length; i++) {
+      fields.push(this._buildFieldsForKeys(model, data[i], allKeys, excludeIds));
     }
   }
   return fields;

--- a/test/connectors/test-sql-connector.js
+++ b/test/connectors/test-sql-connector.js
@@ -84,10 +84,6 @@ TestConnector.prototype.escapeValue = function(value) {
   return value;
 };
 
-TestConnector.prototype.toColumnValue = function(prop, val) {
-  return val;
-};
-
 TestConnector.prototype._buildLimit = function(model, limit, offset) {
   if (isNaN(limit)) {
     limit = 0;
@@ -137,8 +133,41 @@ TestConnector.prototype.escapeValue = function(value) {
   return value;
 };
 
+function realisticSQLToColumnValue(prop, val) {
+  if (val == null) {
+    return null;
+  }
+  if (prop.type === String) {
+    return String(val);
+  }
+  if (prop.type === Number) {
+    if (isNaN(val)) {
+      // Map NaN to NULL
+      return val;
+    }
+    return val;
+  }
+
+  if (prop.type === Date || prop.type.name === 'Timestamp') {
+    if (!val.toUTCString) {
+      val = new Date(val);
+    }
+    return val;
+  }
+
+  if (prop.type === Boolean) {
+    if (val) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  return this.serializeObject(val);
+}
+
 TestConnector.prototype.toColumnValue = function(prop, val, escaping) {
-  return escaping ? this.escapeValue(val) : val;
+  return escaping ? this.escapeValue(val) : realisticSQLToColumnValue(prop, val);
 };
 
 TestConnector.prototype._buildLimit = function(model, limit, offset) {

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -36,13 +36,13 @@ describe('sql connector', function() {
             dataLength: 32,
           },
         }, middleName: {
-          type: Boolean,
+          type: String,
           name: 'middle_name',
           postgresql: {
             column: 'MIDDLENAME',
           },
         }, lastName: {
-          type: Boolean,
+          type: String,
           name: 'last_name',
           testdb: {
             column: 'LASTNAME',
@@ -581,6 +581,19 @@ describe('sql connector', function() {
         sql:
       'INSERT INTO `CUSTOMER`(`NAME`,`middle_name`,`VIP`) VALUES ($1,$2,$3), ($4,$5,$6)',
         params: ['Adam', 'abc', true, 'Test', null, false],
+      });
+    });
+
+    it('should build INSERT for array w/ undefined properties in first row', function() {
+      connector.multiInsertSupported = true;
+      const sql = connector.buildInsertAll('customer', [
+        {name: 'Adam', middleName: 'abc'},
+        {name: 'Test', middleName: null, vip: false},
+      ]);
+      expect(sql.toJSON()).to.eql({
+        sql:
+      'INSERT INTO `CUSTOMER`(`NAME`,`middle_name`,`VIP`) VALUES ($1,$2,$3), ($4,$5,$6)',
+        params: ['Adam', 'abc', null, 'Test', null, false],
       });
     });
 


### PR DESCRIPTION
Insert all only inserted properties based on the properties of the first item in the data array.

Thus, `.createAll([{firstName: 'Kyle'},{firstName:'Kyler',lastName:'Hoskins'}])` would drop the last name entirely unless it was the first item in the array

I included a new test case to highlight the use case the existing `buildFieldsFromArray` fails under.

I modified two other parts of the test files:

1. The test model was using incorrect types for middle name and last name.  This was highlighted because:
2. I added a more realistic toColumnValue based on mssql and postgres connectors, which return a value for undefined keys such that parameter numbers match 

## Checklist

- [X] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [X] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
