### PR TITLE
chore: drop Node.js 20 support

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
         include:
           - os: macos-latest
             node_version: 22

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "7.0.6",
   "description": "Building blocks for LoopBack connectors",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
-  "author": "IBM Corp.",
+  "author": "IBM Corp. and LoopBack contributors",
   "keywords": [
     "StrongLoop",
     "LoopBack",


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js 20 support

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
